### PR TITLE
Use cl-lib

### DIFF
--- a/helm-migemo.el
+++ b/helm-migemo.el
@@ -6,7 +6,7 @@
 ;; Maintainer: Yuhei Maeda <yuhei.maeda_at_gmail.com>
 ;; Version: 1.20
 ;; Package-version: 1.20
-;; Package-Requires: ((helm "1.5.3") (migemo "1.9"))
+;; Package-Requires: ((helm "1.5.3") (migemo "1.9") (cl-lib "0.5"))
 ;; Created: 2009-04-13 
 ;; Keywords: matching, convenience, tools, i18n
 ;; URL: https://github.com/emacs-helm/helm-migemo
@@ -128,6 +128,7 @@
 
 ;;; Code:
 
+(require 'cl-lib)
 (eval-when-compile (require 'helm))
 (require 'migemo nil t)
 (require 'helm-match-plugin nil t)
@@ -142,15 +143,15 @@ With prefix arugument, `helm-pattern' is migemo-ized, otherwise normal `helm'."
 
 (defvar helm-previous-migemo-info '("" . "")
   "[Internal] Previous migemo query for helm-migemo.")
-(defun* helm-string-match-with-migemo (str &optional (pattern helm-pattern))
+(cl-defun helm-string-match-with-migemo (str &optional (pattern helm-pattern))
   "Migemo version of `string-match'."
   (unless (string= pattern (car helm-previous-migemo-info))
     (setq helm-previous-migemo-info (cons pattern (migemo-get-pattern pattern))))
   (string-match (cdr helm-previous-migemo-info) str))
 
-  (defun* helm-mp-3migemo-match (str &optional (pattern helm-pattern))
-    (loop for (pred . re) in (helm-mp-3-get-patterns pattern)
-          always (funcall pred (helm-string-match-with-migemo str re))))
+  (cl-defun helm-mp-3migemo-match (str &optional (pattern helm-pattern))
+    (cl-loop for (pred . re) in (helm-mp-3-get-patterns pattern)
+             always (funcall pred (helm-string-match-with-migemo str re))))
   (defun helm-mp-3migemo-search (pattern &rest ignore)
     (helm-mp-3-search-base pattern 'migemo-forward 'migemo-forward))
   (defun helm-mp-3migemo-search-backward (pattern &rest ignore)


### PR DESCRIPTION
Hi.

helm-migemo seems using cl library, but doesn't load it.
I think [line 131](https://github.com/emacs-helm/helm-migemo/blob/master/helm-migemo.el#L131) is to load cl, but helm is using cl-lib instead of it now.

Would you change to use cl-lib?