### PR TITLE
Fix load error

### DIFF
--- a/helm-migemo.el
+++ b/helm-migemo.el
@@ -129,7 +129,7 @@
 ;;; Code:
 
 (require 'cl-lib)
-(eval-when-compile (require 'helm))
+(require 'helm)
 (require 'migemo nil t)
 (require 'helm-match-plugin nil t)
 (defvar helm-use-migemo nil


### PR DESCRIPTION
The following error is occured by using current helm ( https://github.com/emacs-helm/helm/commit/1e7925c70135390814aa01a7782b0f351d1b5312 ) with byte compile.

```
Debugger entered--Lisp error: (void-variable helm-compile-source-functions)
  add-to-list(helm-compile-source-functions helm-compile-source--migemo t)
  require(helm-migemo)
  eval-buffer(#<buffer  *load*> nil "/Users/masutaka/.emacs.d/init.el" nil t)  ; Reading at buffer position 13133
  load-with-code-conversion("/Users/masutaka/.emacs.d/init.el" "/Users/masutaka/.emacs.d/init.el" t t)
  load("/Users/masutaka/.emacs.d/init" t t)
;; snip
```

I solved the problem with this patch. Do you have any idea?