### PR TITLE
Remove unnecessary require

### DIFF
--- a/helm-migemo.el
+++ b/helm-migemo.el
@@ -131,7 +131,6 @@
 (require 'cl-lib)
 (require 'helm)
 (require 'migemo nil t)
-(require 'helm-match-plugin nil t)
 (defvar helm-use-migemo nil
   "[Internal] If non-nil, `helm' is migemo-ized.")
 (defun helm-migemo (with-migemo &rest helm-args)


### PR DESCRIPTION
> https://github.com/emacs-helm/helm-migemo/pull/2#issuecomment-131818689
>
> Thanks. The require of helm-match-plugin can be removed too (it is now required in helm).

Just removed.